### PR TITLE
Use `assert()` to check stream factory return

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ the normal `ContentTypeMiddleware::__construct()` instead of
 We do have a small preference for the mentioned packages and didn't want to reinvent
 the wheel... but you know, it's a free world.
 
+## PHP Configuration
+
+In order to make sure that other components are returning the expected objects we decided
+to use `assert()`, which is a very interesting feature in PHP but not often used.
+The nice thing about `assert()` is that we can (and should) disable it in production mode
+so that we don't have useless statements.
+
+So, for production mode, we recommend you to set `zend.assertions` to `-1` in your `php.ini`.
+For development you should leave `zend.assertions` as `1` and set `assert.exception` to `1`, which
+will make PHP throw an [`AssertionError`](https://secure.php.net/manual/en/class.assertionerror.php)
+when things go wrong.
+
+Check the documentation for more information: https://secure.php.net/manual/en/function.assert.php
+
 ## Usage
 
 Your very first step is to create the middleware using the correct configuration:

--- a/src/ContentTypeMiddleware.php
+++ b/src/ContentTypeMiddleware.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Stream;
+use function assert;
 use function strpos;
 use function substr;
 
@@ -56,8 +57,8 @@ final class ContentTypeMiddleware implements MiddlewareInterface
         return new self(
             new ContentType($formats),
             $formatters,
-            function () use ($streamFactory): StreamInterface {
-                return $streamFactory !== null ? $streamFactory() : new Stream('php://temp', 'wb+');
+            $streamFactory ?? function (): StreamInterface {
+                return new Stream('php://temp', 'wb+');
             }
         );
     }
@@ -97,8 +98,9 @@ final class ContentTypeMiddleware implements MiddlewareInterface
      */
     private function formatResponse(UnformattedResponse $response, ?Formatter $formatter): ResponseInterface
     {
-        /** @var StreamInterface $body */
-        $body     = ($this->streamFactory)();
+        $body = ($this->streamFactory)();
+        assert($body instanceof StreamInterface);
+
         $response = $response->withBody($body);
 
         if ($formatter === null) {


### PR DESCRIPTION
Simplifying the code, turning a docblock into something which is actually validated in development mode, and making people happier.