### PR TITLE
Enable phpstan-phpunit rules

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:


### PR DESCRIPTION
To ensure we're also checking for good practices regarding PHPUnit's usage.