### PR TITLE
Exclude project tests from distribution file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/tests               export-ignore
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
 /.scrutinizer.yml    export-ignore


### PR DESCRIPTION
Because nobody needs to download files that won't actually be used on their project.