### PR TITLE
Allow raw formatter returning complete response

### DIFF
--- a/src/ContentTypeMiddleware.php
+++ b/src/ContentTypeMiddleware.php
@@ -85,17 +85,25 @@ final class ContentTypeMiddleware implements MiddlewareInterface
     /**
      * @throws ContentCouldNotBeFormatted
      */
-    private function formatResponse(UnformattedResponse $response, ?Formatter $formatter): ResponseInterface
+    private function formatResponse(UnformattedResponse $response, $formatter): ResponseInterface
     {
         if ($formatter === null) {
             return $response->withBody($this->streamFactory->createStream())
                             ->withStatus(StatusCodeInterface::STATUS_NOT_ACCEPTABLE);
         }
 
-        return $response->withBody(
-            $this->streamFactory->createStream(
-                $formatter->format($response->getUnformattedContent(), $response->getAttributes())
-            )
-        );
+        if ($formatter instanceof RawFormatter) {
+            return $formatter->format($response);
+        }
+
+        if ($formatter instanceof Formatter) {
+            return $response->withBody(
+                $this->streamFactory->createStream(
+                    $formatter->format($response->getUnformattedContent(), $response->getAttributes())
+                )
+            );
+        }
+
+        throw new ContentCouldNotBeFormatted('bad formatter');
     }
 }

--- a/src/RawFormatter.php
+++ b/src/RawFormatter.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\ContentNegotiation;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface RawFormatter
+{
+    /**
+     * @throws ContentCouldNotBeFormatted
+     */
+    public function format(UnformattedResponse $response): ResponseInterface;
+}


### PR DESCRIPTION
This allows to use formatting library returning complete response.
E.g. `woohoolabs/yin` returns whole Psr7 response and it's not
reasonable to convert it to string and back to be compatible with
current `Formatter` interface.

I can add tests if you're ok with the idea.