### PR TITLE
Change `Formatter` interface to allow returning complete PSR 7 response

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,17 @@ declare(strict_types=1);
 namespace Me\MyApp;
 
 use Lcobucci\ContentNegotiation\Formatter;
+use Lcobucci\ContentNegotiation\UnformattedResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 final class MyFancyFormatter implements Formatter
 {
-    public function format($content, array $attributes = []): string
+    public function format(UnformattedResponse $response, StreamFactoryInterface $streamFactory): ResponseInterface
     {
-        // Performs all the magic with $content and creates $result with a
-        // `string` containing the formatted data.
+        $content = ''; // Do some fancy formatting of $response->getUnformattedContent() and put into $content
 
-        return $result;
+        return $response->withBody($streamFactory->createStream($content));
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ composer require lcobucci/content-negotiation-middleware middlewares/negotiation
 ### Adventure mode
 
 If you're ready for an adventure and don't want to use `middlewares/negotiation`
-to handle the detection or `zendframework/zend-diactoros` to create the response
+to handle the detection or `laminas/diactoros` to create the response
 body (`StreamInterface` implementation), don't despair! You'll only have to use
 the normal `ContentTypeMiddleware::__construct()` instead of
 `ContentTypeMiddleware::fromRecommendedSettings()`.
@@ -53,7 +53,7 @@ The nice thing about `assert()` is that we can (and should) disable it in produc
 so that we don't have useless statements.
 
 So, for production mode, we recommend you to set `zend.assertions` to `-1` in your `php.ini`.
-For development you should leave `zend.assertions` as `1` and set `assert.exception` to `1`, which
+For development, you should leave `zend.assertions` as `1` and set `assert.exception` to `1`, which
 will make PHP throw an [`AssertionError`](https://secure.php.net/manual/en/class.assertionerror.php)
 when things go wrong.
 
@@ -70,7 +70,7 @@ declare(strict_types=1);
 use Lcobucci\ContentNegotiation\ContentTypeMiddleware;
 use Lcobucci\ContentNegotiation\Formatter\Json;
 use Lcobucci\ContentNegotiation\Formatter\StringCast;
-use Zend\Diactoros\StreamFactory;
+use Laminas\Diactoros\StreamFactory;
 
 $middleware = ContentTypeMiddleware::fromRecommendedSettings(
     // First argument is the list of formats you want to support:
@@ -130,7 +130,7 @@ use Lcobucci\ContentNegotiation\UnformattedResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 final class MyHandler implements RequestHandlerInterface
 {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     },
     "require": {

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Lcobucci\ContentNegotiation;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
 interface Formatter
 {
     /**
-     * @param mixed   $content
-     * @param mixed[] $attributes
-     *
      * @throws ContentCouldNotBeFormatted
      */
-    public function format($content, array $attributes = []): string;
+    public function format(UnformattedResponse $response, StreamFactoryInterface $streamFactory): ResponseInterface;
 }

--- a/src/Formatter/ContentOnly.php
+++ b/src/Formatter/ContentOnly.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\ContentNegotiation\Formatter;
+
+use Lcobucci\ContentNegotiation\ContentCouldNotBeFormatted;
+use Lcobucci\ContentNegotiation\Formatter;
+use Lcobucci\ContentNegotiation\UnformattedResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+abstract class ContentOnly implements Formatter
+{
+    /** @throws ContentCouldNotBeFormatted */
+    public function format(UnformattedResponse $response, StreamFactoryInterface $streamFactory): ResponseInterface
+    {
+        return $response->withBody(
+            $streamFactory->createStream(
+                $this->formatContent($response->getUnformattedContent(), $response->getAttributes())
+            )
+        );
+    }
+
+    /**
+     * @param mixed   $content
+     * @param mixed[] $attributes
+     */
+    abstract public function formatContent($content, array $attributes = []): string;
+}

--- a/src/Formatter/JmsSerializer.php
+++ b/src/Formatter/JmsSerializer.php
@@ -5,11 +5,10 @@ namespace Lcobucci\ContentNegotiation\Formatter;
 
 use JMS\Serializer\SerializerInterface;
 use Lcobucci\ContentNegotiation\ContentCouldNotBeFormatted;
-use Lcobucci\ContentNegotiation\Formatter;
 use Throwable;
 use function sprintf;
 
-final class JmsSerializer implements Formatter
+final class JmsSerializer extends ContentOnly
 {
     private SerializerInterface $serializer;
     private string $format;
@@ -23,7 +22,7 @@ final class JmsSerializer implements Formatter
     /**
      * {@inheritdoc}
      */
-    public function format($content, array $attributes = []): string
+    public function formatContent($content, array $attributes = []): string
     {
         try {
             return $this->serializer->serialize($content, $this->format);

--- a/src/Formatter/Json.php
+++ b/src/Formatter/Json.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Lcobucci\ContentNegotiation\Formatter;
 
 use Lcobucci\ContentNegotiation\ContentCouldNotBeFormatted;
-use Lcobucci\ContentNegotiation\Formatter;
 use Throwable;
 use function json_encode;
 use function sprintf;
@@ -15,7 +14,7 @@ use const JSON_HEX_TAG;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 
-final class Json implements Formatter
+final class Json extends ContentOnly
 {
     private const DEFAULT_FLAGS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES;
 
@@ -29,7 +28,7 @@ final class Json implements Formatter
     /**
      * {@inheritdoc}
      */
-    public function format($content, array $attributes = []): string
+    public function formatContent($content, array $attributes = []): string
     {
         try {
             return json_encode($content, $this->flags | JSON_THROW_ON_ERROR);

--- a/src/Formatter/NotAcceptable.php
+++ b/src/Formatter/NotAcceptable.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\ContentNegotiation\Formatter;
+
+use Fig\Http\Message\StatusCodeInterface;
+use Lcobucci\ContentNegotiation\Formatter;
+use Lcobucci\ContentNegotiation\UnformattedResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+class NotAcceptable implements Formatter
+{
+    public function format(UnformattedResponse $response, StreamFactoryInterface $streamFactory): ResponseInterface
+    {
+        return $response->withBody($streamFactory->createStream())
+                        ->withStatus(StatusCodeInterface::STATUS_NOT_ACCEPTABLE);
+    }
+}

--- a/src/Formatter/Plates.php
+++ b/src/Formatter/Plates.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 namespace Lcobucci\ContentNegotiation\Formatter;
 
 use Lcobucci\ContentNegotiation\ContentCouldNotBeFormatted;
-use Lcobucci\ContentNegotiation\Formatter;
 use League\Plates\Engine;
 use Throwable;
 
-final class Plates implements Formatter
+final class Plates extends ContentOnly
 {
     private const DEFAULT_ATTRIBUTE = 'template';
 
@@ -24,7 +23,7 @@ final class Plates implements Formatter
     /**
      * {@inheritdoc}
      */
-    public function format($content, array $attributes = []): string
+    public function formatContent($content, array $attributes = []): string
     {
         try {
             return $this->render($content, $attributes);

--- a/src/Formatter/StringCast.php
+++ b/src/Formatter/StringCast.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 namespace Lcobucci\ContentNegotiation\Formatter;
 
 use Lcobucci\ContentNegotiation\ContentCouldNotBeFormatted;
-use Lcobucci\ContentNegotiation\Formatter;
 use function is_object;
 use function method_exists;
 
-final class StringCast implements Formatter
+final class StringCast extends ContentOnly
 {
     /**
      * {@inheritdoc}
      */
-    public function format($content, array $attributes = []): string
+    public function formatContent($content, array $attributes = []): string
     {
         if (is_object($content) && ! method_exists($content, '__toString')) {
             throw new ContentCouldNotBeFormatted('Given data could not be cast to string');

--- a/src/Formatter/Twig.php
+++ b/src/Formatter/Twig.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 namespace Lcobucci\ContentNegotiation\Formatter;
 
 use Lcobucci\ContentNegotiation\ContentCouldNotBeFormatted;
-use Lcobucci\ContentNegotiation\Formatter;
 use Throwable;
 use Twig\Environment;
 
-final class Twig implements Formatter
+final class Twig extends ContentOnly
 {
     private const DEFAULT_ATTRIBUTE = 'template';
 
@@ -26,7 +25,7 @@ final class Twig implements Formatter
     /**
      * {@inheritdoc}
      */
-    public function format($content, array $attributes = []): string
+    public function formatContent($content, array $attributes = []): string
     {
         try {
             return $this->render($content, $attributes);

--- a/tests/ContentTypeMiddlewareTest.php
+++ b/tests/ContentTypeMiddlewareTest.php
@@ -46,6 +46,7 @@ final class ContentTypeMiddlewareTest extends TestCase
      * @covers ::process()
      *
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json
+     * @uses \Lcobucci\ContentNegotiation\Formatter\ContentOnly
      */
     public function processShouldReturnFormattedResponseDirectly(): void
     {
@@ -64,10 +65,10 @@ final class ContentTypeMiddlewareTest extends TestCase
      * @covers ::fromRecommendedSettings()
      * @covers ::process()
      * @covers ::extractContentType()
-     * @covers ::formatResponse()
      *
      * @uses \Lcobucci\ContentNegotiation\UnformattedResponse
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json
+     * @uses \Lcobucci\ContentNegotiation\Formatter\NotAcceptable
      */
     public function processShouldReturnAResponseWithErrorWhenFormatterWasNotFound(): void
     {
@@ -90,9 +91,9 @@ final class ContentTypeMiddlewareTest extends TestCase
      * @covers ::fromRecommendedSettings()
      * @covers ::process()
      * @covers ::extractContentType()
-     * @covers ::formatResponse()
      *
      * @uses \Lcobucci\ContentNegotiation\UnformattedResponse
+     * @uses \Lcobucci\ContentNegotiation\Formatter\ContentOnly
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json
      */
     public function processShouldReturnAResponseWithFormattedContent(): void
@@ -117,9 +118,9 @@ final class ContentTypeMiddlewareTest extends TestCase
      * @covers ::fromRecommendedSettings()
      * @covers ::process()
      * @covers ::extractContentType()
-     * @covers ::formatResponse()
      *
      * @uses \Lcobucci\ContentNegotiation\UnformattedResponse
+     * @uses \Lcobucci\ContentNegotiation\Formatter\ContentOnly
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json
      */
     public function processShouldPassAttributesToTheFormatterProperly(): void
@@ -148,9 +149,9 @@ final class ContentTypeMiddlewareTest extends TestCase
      * @covers ::fromRecommendedSettings()
      * @covers ::process()
      * @covers ::extractContentType()
-     * @covers ::formatResponse()
      *
      * @uses \Lcobucci\ContentNegotiation\UnformattedResponse
+     * @uses \Lcobucci\ContentNegotiation\Formatter\ContentOnly
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json
      */
     public function processShouldReturnAResponseWithFormattedContentEvenWithoutForcingTheCharset(): void

--- a/tests/Formatter/ContentOnlyTest.php
+++ b/tests/Formatter/ContentOnlyTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\ContentNegotiation\Tests\Formatter;
+
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\StreamFactory;
+use Lcobucci\ContentNegotiation\Formatter\ContentOnly;
+use Lcobucci\ContentNegotiation\UnformattedResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Lcobucci\ContentNegotiation\Formatter\ContentOnly
+ */
+final class ContentOnlyTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::format
+     *
+     * @uses \Lcobucci\ContentNegotiation\UnformattedResponse
+     */
+    public function formatShouldDelegateTheFormattingToTheConcreteClasses(): void
+    {
+        $formatter = $this->getMockForAbstractClass(ContentOnly::class);
+        $formatter->method('formatContent')->willReturn('A fancy result');
+
+        $response = $formatter->format(new UnformattedResponse(new Response(), 'testing'), new StreamFactory());
+
+        self::assertSame('A fancy result', $response->getBody()->getContents());
+    }
+}

--- a/tests/Formatter/JmsSerializerTest.php
+++ b/tests/Formatter/JmsSerializerTest.php
@@ -32,7 +32,7 @@ final class JmsSerializerTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      */
     public function formatShouldSimplyForwardCallToSerializer(): void
     {
@@ -45,14 +45,14 @@ final class JmsSerializerTest extends TestCase
 
         $formatter = new JmsSerializer($this->serializer, 'json');
 
-        self::assertSame('{"a":"test"}', $formatter->format($content));
+        self::assertSame('{"a":"test"}', $formatter->formatContent($content));
     }
 
     /**
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      */
     public function formatShouldConvertAnyRaisedException(): void
     {
@@ -62,6 +62,6 @@ final class JmsSerializerTest extends TestCase
                          ->willThrowException(new RuntimeException());
 
         $formatter = new JmsSerializer($this->serializer, 'json');
-        $formatter->format(['a' => 'test']);
+        $formatter->formatContent(['a' => 'test']);
     }
 }

--- a/tests/Formatter/JsonTest.php
+++ b/tests/Formatter/JsonTest.php
@@ -22,13 +22,14 @@ final class JsonTest extends TestCase
      *
      * @covers ::__construct()
      *
-     * @uses \Lcobucci\ContentNegotiation\Formatter\Json::format()
+     * @uses \Lcobucci\ContentNegotiation\Formatter\Json::formatContent()
      */
     public function constructorShouldAllowTheConfigurationOfEncodingFlags(): void
     {
         self::assertSame(
             '["<foo>","\'bar\'","\"baz\"","&blong&","\u00e9","http://"]',
-            (new Json(JSON_UNESCAPED_SLASHES))->format(['<foo>', "'bar'", '"baz"', '&blong&', "\xc3\xa9", 'http://'])
+            (new Json(JSON_UNESCAPED_SLASHES))
+                ->formatContent(['<foo>', "'bar'", '"baz"', '&blong&', "\xc3\xa9", 'http://'])
         );
     }
 
@@ -37,20 +38,20 @@ final class JsonTest extends TestCase
      *
      * @covers ::__construct()
      *
-     * @uses \Lcobucci\ContentNegotiation\Formatter\Json::format()
+     * @uses \Lcobucci\ContentNegotiation\Formatter\Json::formatContent()
      */
     public function constructorShouldUseDefaultFlagsWhenNothingWasSet(): void
     {
         self::assertSame(
             '["\u003Cfoo\u003E","\u0027bar\u0027","\u0022baz\u0022","\u0026blong\u0026","\u00e9","http://"]',
-            $this->format(['<foo>', "'bar'", '"baz"', '&blong&', "\xc3\xa9", 'http://'])
+            $this->formatContent(['<foo>', "'bar'", '"baz"', '&blong&', "\xc3\xa9", 'http://'])
         );
     }
 
     /**
      * @test
      *
-     * @covers ::format()
+     * @covers ::formatContent()
      *
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json::__construct()
      */
@@ -58,14 +59,14 @@ final class JsonTest extends TestCase
     {
         self::assertJsonStringEqualsJsonString(
             '{"id":1,"name":"Test"}',
-            $this->format(new PersonDto(1, 'Test'))
+            $this->formatContent(new PersonDto(1, 'Test'))
         );
     }
 
     /**
      * @test
      *
-     * @covers ::format()
+     * @covers ::formatContent()
      *
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json::__construct()
      */
@@ -74,13 +75,13 @@ final class JsonTest extends TestCase
         $this->expectException(ContentCouldNotBeFormatted::class);
         $this->expectExceptionMessage('Inf and NaN cannot be JSON encoded');
 
-        $this->format(acos(8));
+        $this->formatContent(acos(8));
     }
 
     /**
      * @test
      *
-     * @covers ::format()
+     * @covers ::formatContent()
      *
      * @uses \Lcobucci\ContentNegotiation\Formatter\Json::__construct()
      */
@@ -89,7 +90,7 @@ final class JsonTest extends TestCase
         $this->expectException(ContentCouldNotBeFormatted::class);
         $this->expectExceptionMessage('An exception was thrown during JSON formatting');
 
-        $this->format(
+        $this->formatContent(
             new class implements JsonSerializable
             {
                 public function jsonSerialize(): void
@@ -103,10 +104,10 @@ final class JsonTest extends TestCase
     /**
      * @param mixed $content
      */
-    private function format($content): string
+    private function formatContent($content): string
     {
         $formatter = new Json();
 
-        return $formatter->format($content);
+        return $formatter->formatContent($content);
     }
 }

--- a/tests/Formatter/NaiveTemplateEngine.php
+++ b/tests/Formatter/NaiveTemplateEngine.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\ContentNegotiation\Tests\Formatter;
 
-use Lcobucci\ContentNegotiation\Formatter;
+use Lcobucci\ContentNegotiation\Formatter\ContentOnly;
 use SplFileObject;
 use function array_keys;
 use function array_map;
@@ -12,7 +12,7 @@ use function is_string;
 use function str_replace;
 use function trim;
 
-final class NaiveTemplateEngine implements Formatter
+final class NaiveTemplateEngine extends ContentOnly
 {
     private const BASE_DIR  = __DIR__ . '/../../templates/naive/';
     private const EXTENSION = 'html';
@@ -20,7 +20,7 @@ final class NaiveTemplateEngine implements Formatter
     /**
      * {@inheritdoc}
      */
-    public function format($content, array $attributes = []): string
+    public function formatContent($content, array $attributes = []): string
     {
         $template = $this->getTemplateContent($attributes);
 

--- a/tests/Formatter/NotAcceptableTest.php
+++ b/tests/Formatter/NotAcceptableTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\ContentNegotiation\Tests\Formatter;
+
+use Fig\Http\Message\StatusCodeInterface;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\StreamFactory;
+use Lcobucci\ContentNegotiation\Formatter\NotAcceptable;
+use Lcobucci\ContentNegotiation\UnformattedResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Lcobucci\ContentNegotiation\Formatter\NotAcceptable
+ */
+final class NotAcceptableTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::format
+     *
+     * @uses \Lcobucci\ContentNegotiation\UnformattedResponse
+     */
+    public function formatShouldReturnAResponseWithEmptyBodyAndTheCorrectStatusCode(): void
+    {
+        $formatter = new NotAcceptable();
+        $response  = $formatter->format(new UnformattedResponse(new Response(), 'testing'), new StreamFactory());
+
+        self::assertSame('', $response->getBody()->getContents());
+        self::assertSame(StatusCodeInterface::STATUS_NOT_ACCEPTABLE, $response->getStatusCode());
+    }
+}

--- a/tests/Formatter/PlatesTest.php
+++ b/tests/Formatter/PlatesTest.php
@@ -29,13 +29,13 @@ final class PlatesTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      * @covers ::render()
      */
     public function formatShouldReturnContentFormattedByPlates(): void
     {
         $formatter = new Plates($this->engine);
-        $content   = $formatter->format(new PersonDto(1, 'Testing'), ['template' => 'person']);
+        $content   = $formatter->formatContent(new PersonDto(1, 'Testing'), ['template' => 'person']);
 
         self::assertStringContainsString('<dd>1</dd>', $content);
         self::assertStringContainsString('<dd>Testing</dd>', $content);
@@ -45,13 +45,13 @@ final class PlatesTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      * @covers ::render()
      */
     public function formatShouldReadTemplateNameFromCustomAttribute(): void
     {
         $formatter = new Plates($this->engine, 'fancy!');
-        $content   = $formatter->format(new PersonDto(1, 'Testing'), ['fancy!' => 'person']);
+        $content   = $formatter->formatContent(new PersonDto(1, 'Testing'), ['fancy!' => 'person']);
 
         self::assertStringContainsString('<dd>1</dd>', $content);
         self::assertStringContainsString('<dd>Testing</dd>', $content);
@@ -61,7 +61,7 @@ final class PlatesTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      * @covers ::render()
      */
     public function formatShouldConvertAnyPlatesException(): void
@@ -71,6 +71,6 @@ final class PlatesTest extends TestCase
         $this->expectException(ContentCouldNotBeFormatted::class);
         $this->expectExceptionMessage('An error occurred while formatting using plates');
 
-        $formatter->format(new PersonDto(1, 'Testing'), ['template' => 'no-template-at-all']);
+        $formatter->formatContent(new PersonDto(1, 'Testing'), ['template' => 'no-template-at-all']);
     }
 }

--- a/tests/Formatter/StringCastTest.php
+++ b/tests/Formatter/StringCastTest.php
@@ -16,7 +16,7 @@ final class StringCastTest extends TestCase
      * @test
      * @dataProvider validData
      *
-     * @covers ::format()
+     * @covers ::formatContent()
      *
      * @param mixed $content
      */
@@ -26,7 +26,7 @@ final class StringCastTest extends TestCase
     ): void {
         $formatter = new StringCast();
 
-        self::assertSame($expected, $formatter->format($content));
+        self::assertSame($expected, $formatter->formatContent($content));
     }
 
     /**
@@ -55,7 +55,7 @@ final class StringCastTest extends TestCase
     /**
      * @test
      *
-     * @covers ::format()
+     * @covers ::formatContent()
      */
     public function formatShouldRaiseExceptionWhenContentCouldNotBeCastToString(): void
     {
@@ -66,6 +66,6 @@ final class StringCastTest extends TestCase
         };
 
         $formatter = new StringCast();
-        $formatter->format($content);
+        $formatter->formatContent($content);
     }
 }

--- a/tests/Formatter/TwigTest.php
+++ b/tests/Formatter/TwigTest.php
@@ -32,13 +32,13 @@ final class TwigTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      * @covers ::render()
      */
     public function formatShouldReturnContentFormattedByPlates(): void
     {
         $formatter = new Twig($this->environment);
-        $content   = $formatter->format(new PersonDto(1, 'Testing'), ['template' => 'person.twig']);
+        $content   = $formatter->formatContent(new PersonDto(1, 'Testing'), ['template' => 'person.twig']);
 
         self::assertStringContainsString('<dd>1</dd>', $content);
         self::assertStringContainsString('<dd>Testing</dd>', $content);
@@ -48,13 +48,13 @@ final class TwigTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      * @covers ::render()
      */
     public function formatShouldReadTemplateNameFromCustomAttribute(): void
     {
         $formatter = new Twig($this->environment, 'fancy!');
-        $content   = $formatter->format(new PersonDto(1, 'Testing'), ['fancy!' => 'person.twig']);
+        $content   = $formatter->formatContent(new PersonDto(1, 'Testing'), ['fancy!' => 'person.twig']);
 
         self::assertStringContainsString('<dd>1</dd>', $content);
         self::assertStringContainsString('<dd>Testing</dd>', $content);
@@ -64,7 +64,7 @@ final class TwigTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::format()
+     * @covers ::formatContent()
      * @covers ::render()
      */
     public function formatShouldConvertAnyTwigException(): void
@@ -74,6 +74,6 @@ final class TwigTest extends TestCase
         $this->expectException(ContentCouldNotBeFormatted::class);
         $this->expectExceptionMessage('An error occurred while formatting using twig');
 
-        $formatter->format(new PersonDto(1, 'Testing'), ['template' => 'no-template-at-all']);
+        $formatter->formatContent(new PersonDto(1, 'Testing'), ['template' => 'no-template-at-all']);
     }
 }


### PR DESCRIPTION
Continuing #49

Not finished: not all tests fixed.
Let me know if it is ok to you and I'll finish.

Pay attention to `ContentTypeMiddleware::NOT_ACCEPTABLE` constant and `getNotAcceptableFormatter()`.
It allows redefine formatter for not acceptable case in the formatters map.
